### PR TITLE
feat: kube-authkit OIDC authentication (Phase 1)

### DIFF
--- a/docs/auth/AUTH-USE-CASES.md
+++ b/docs/auth/AUTH-USE-CASES.md
@@ -1,0 +1,272 @@
+# Authentication Use Cases
+
+Practical examples for every authentication scenario supported by the SDK
+when backed by kube-authkit.
+
+---
+
+## UC-1: CI/CD with OIDC Client Credentials
+
+```python
+from kubeflow.trainer import TrainerClient
+
+client = TrainerClient(backend_config={
+    "auth_method": "oidc",
+    "oidc_issuer": "https://keycloak.example.com/realms/rhoai",
+    "client_id": "training-pipeline",
+    "client_secret": "my-secret",
+    "use_client_credentials": True,
+    "k8s_api_host": "https://api.cluster:6443",
+})
+```
+
+kube-authkit exchanges client credentials for an access token. The adapter
+auto-refreshes via `get_token()` when the token expires.
+
+---
+
+## UC-2: Environment-Only Auth
+
+```bash
+export KUBEFLOW_OIDC_ISSUER=https://keycloak.example.com/realms/rhoai
+export KUBEFLOW_OIDC_CLIENT_ID=training-pipeline
+export KUBEFLOW_OIDC_CLIENT_SECRET=my-secret
+export KUBEFLOW_API_HOST=https://api.cluster:6443
+```
+
+```python
+from kubeflow.trainer import TrainerClient
+
+client = TrainerClient()  # Picks up KUBEFLOW_* env vars automatically
+```
+
+---
+
+## UC-3: Device Flow (Headless Notebook)
+
+```python
+from kubeflow.trainer import TrainerClient
+
+client = TrainerClient(backend_config={
+    "auth_method": "oidc",
+    "oidc_issuer": "https://keycloak.example.com/realms/rhoai",
+    "client_id": "jupyter-client",
+    "use_device_flow": True,
+    "k8s_api_host": "https://api.cluster:6443",
+})
+# Prints: "Visit https://keycloak.example.com/device and enter code: ABCD-EFGH"
+```
+
+---
+
+## UC-4: Browser Flow with PKCE
+
+```python
+from kubeflow.trainer import TrainerClient
+
+client = TrainerClient(backend_config={
+    "auth_method": "oidc",
+    "oidc_issuer": "https://keycloak.example.com/realms/rhoai",
+    "client_id": "my-app",
+    "k8s_api_host": "https://api.cluster:6443",
+})
+# Opens browser for interactive authentication
+```
+
+---
+
+## UC-5: Existing Kubeconfig / `oc login`
+
+```python
+from kubeflow.trainer import TrainerClient
+
+# Uses ~/.kube/config automatically (no extra config needed)
+client = TrainerClient()
+```
+
+Or with an explicit path:
+
+```python
+client = TrainerClient(backend_config={
+    "config_file": "/custom/path/kubeconfig",
+})
+```
+
+---
+
+## UC-6: In-Cluster Service Account
+
+```python
+from kubeflow.trainer import TrainerClient
+
+# Auto-detected when running inside a Pod (no config needed)
+client = TrainerClient()
+```
+
+---
+
+## UC-7: Static Token
+
+```python
+from kubeflow.trainer import TrainerClient
+
+client = TrainerClient(backend_config={
+    "token": "sha256~my-openshift-token",
+    "server": "https://api.cluster:6443",
+})
+```
+
+Or via environment:
+
+```bash
+export KUBEFLOW_TOKEN=sha256~my-openshift-token
+export KUBEFLOW_API_HOST=https://api.cluster:6443
+```
+
+---
+
+## UC-8: Same Credentials for K8s + REST (Dual Interface)
+
+```python
+from kubeflow.common.auth import resolve_credentials
+
+creds = resolve_credentials(
+    token="my-token",
+)
+
+# K8s usage -- hook refreshes automatically
+from kubeflow.common.auth import load_kubernetes_config
+api_client = load_kubernetes_config(
+    credentials=creds,
+    server="https://api.cluster:6443",
+)
+
+# REST usage -- same credentials object
+token = creds.get_token()
+# Use token with KFP, Model Registry, etc.
+```
+
+---
+
+## UC-9: Pluggable Custom Credentials (e.g. Vault)
+
+```python
+class VaultCredentials:
+    """Satisfies TokenCredentialsBase protocol."""
+
+    def __init__(self, vault_path: str):
+        self._vault_path = vault_path
+
+    def refresh_api_key_hook(self, config):
+        config.api_key["authorization"] = self.get_token()
+        config.api_key_prefix["authorization"] = "Bearer"
+
+    def get_token(self) -> str:
+        # Fetch fresh token from Vault
+        return vault_client.read(self._vault_path)["token"]
+
+
+from kubeflow.trainer import TrainerClient
+
+client = TrainerClient(backend_config={
+    "credentials": VaultCredentials("/secret/k8s-token"),
+    "server": "https://api.cluster:6443",
+})
+```
+
+---
+
+## UC-10: Identity Propagation
+
+```python
+from kubeflow.common.auth import identity_annotations
+
+token = creds.get_token()
+annotations = identity_annotations(token)
+# {'kubeflow.org/user-id': 'abc123',
+#  'kubeflow.org/user-email': 'user@example.com',
+#  'kubeflow.org/user-name': 'jdoe',
+#  'kubeflow.org/user-groups': 'team-a,team-b'}
+```
+
+These annotations can be set on Jobs/Pods for audit trails.
+
+---
+
+## UC-11: Custom CA / Internal PKI
+
+```python
+from kubeflow.trainer import TrainerClient
+
+client = TrainerClient(backend_config={
+    "auth_method": "oidc",
+    "oidc_issuer": "https://keycloak.internal.corp/realms/rhoai",
+    "client_id": "training",
+    "client_secret": "secret",
+    "use_client_credentials": True,
+    "k8s_api_host": "https://api.internal.corp:6443",
+    "ca_cert": "/etc/pki/tls/certs/corp-ca-bundle.pem",
+    "verify_ssl": True,
+})
+```
+
+---
+
+## UC-12: Keyring Persistence
+
+```python
+from kubeflow.trainer import TrainerClient
+
+client = TrainerClient(backend_config={
+    "auth_method": "oidc",
+    "oidc_issuer": "https://keycloak.example.com/realms/rhoai",
+    "client_id": "jupyter-client",
+    "use_device_flow": True,
+    "use_keyring": True,
+    "k8s_api_host": "https://api.cluster:6443",
+})
+# First run: interactive authentication
+# Subsequent runs: uses stored refresh token from system keyring
+```
+
+---
+
+## UC-13: Long-Running Jobs with Automatic Refresh
+
+```python
+from kubeflow.trainer import TrainerClient
+
+client = TrainerClient(backend_config={
+    "auth_method": "oidc",
+    "oidc_issuer": "https://keycloak.example.com/realms/rhoai",
+    "client_id": "pipeline",
+    "client_secret": "secret",
+    "use_client_credentials": True,
+    "k8s_api_host": "https://api.cluster:6443",
+})
+
+# The K8s client's refresh_api_key_hook ensures every API call
+# uses a fresh token, even in multi-hour training jobs.
+job = client.train(...)
+# Token refreshes transparently during status polling
+```
+
+---
+
+## Use Case Coverage Summary
+
+| UC | Description | Covered | How |
+|----|-------------|---------|-----|
+| 1 | CI/CD client credentials | Yes | `use_client_credentials=True` |
+| 2 | Env-only auth | Yes | `KUBEFLOW_OIDC_*` env vars |
+| 3 | Device flow | Yes | `use_device_flow=True` |
+| 4 | Browser + PKCE | Yes | Default OIDC flow |
+| 5 | Kubeconfig | Yes | Auto-detected or `config_file=` |
+| 6 | In-cluster SA | Yes | Auto-detected |
+| 7 | Static token | Yes | `token=` or `KUBEFLOW_TOKEN` |
+| 8 | Dual K8s+REST | Yes | `TokenCredentialsBase` protocol |
+| 9 | Pluggable credentials | Yes | `credentials=` field |
+| 10 | Identity propagation | Yes | `identity_annotations()` |
+| 11 | Custom CA | Yes | `ca_cert=` + `verify_ssl=` |
+| 12 | Keyring persistence | Yes | `use_keyring=True` |
+| 13 | Long-running refresh | Yes | `refresh_api_key_hook` |

--- a/docs/auth/UNIFIED-AUTH.md
+++ b/docs/auth/UNIFIED-AUTH.md
@@ -1,0 +1,122 @@
+# Unified Authentication Architecture (kube-authkit)
+
+This document describes how the Kubeflow SDK handles authentication using
+[kube-authkit](https://github.com/opendatahub-io/kube-authkit) as the underlying
+auth engine, wrapped behind the SDK's `TokenCredentialsBase` protocol.
+
+## Two-Layer Design
+
+```
+┌─────────────────────────────────────────────┐
+│  SDK Orchestration Layer                    │
+│  (kubeflow.common.auth)                     │
+│                                             │
+│  ┌───────────────┐  ┌────────────────────┐  │
+│  │ resolve_      │  │ load_kubernetes_   │  │
+│  │ credentials() │  │ config()           │  │
+│  └───────┬───────┘  └────────┬───────────┘  │
+│          │                   │              │
+│  ┌───────▼───────────────────▼───────────┐  │
+│  │ TokenCredentialsBase Protocol         │  │
+│  │  - refresh_api_key_hook(config)       │  │
+│  │  - get_token() -> str                 │  │
+│  └───────────────────┬───────────────────┘  │
+│                      │                      │
+│  ┌───────────────────▼───────────────────┐  │
+│  │ _KubeAuthkitAdapter                   │  │
+│  │  wraps kube-authkit AuthStrategy      │  │
+│  └───────────────────────────────────────┘  │
+└─────────────────────────────────────────────┘
+                      │
+┌─────────────────────▼───────────────────────┐
+│  kube-authkit  (external dependency)        │
+│                                             │
+│  AuthFactory → strategy selection           │
+│  ├── OIDCStrategy (client_credentials,      │
+│  │     device flow, browser/PKCE)           │
+│  ├── OpenShiftOAuthStrategy                 │
+│  ├── KubeConfigStrategy                     │
+│  └── InClusterStrategy                      │
+│                                             │
+│  get_token() auto-refreshes expired tokens  │
+└─────────────────────────────────────────────┘
+```
+
+### Layer 1: SDK Orchestration (kubeflow.common.auth)
+
+This layer owns:
+
+- **`TokenCredentialsBase`** -- the Protocol that both K8s and REST clients consume
+- **`resolve_credentials()`** -- the resolution chain (explicit > token > OIDC > env > None)
+- **`load_kubernetes_config()`** -- builds `ApiClient` with `refresh_api_key_hook` wired
+- **`_KubeAuthkitAdapter`** -- wraps kube-authkit strategies as `TokenCredentialsBase`
+- **`identity_annotations()`** -- extracts JWT claims for Kubernetes annotations
+- **Env var conventions** -- `KUBEFLOW_OIDC_*`, `KUBEFLOW_TOKEN`, `KUBEFLOW_API_HOST`
+
+### Layer 2: kube-authkit (auth engine)
+
+kube-authkit handles the actual protocol work:
+
+- OIDC discovery, token exchange, PKCE, device flow
+- OpenShift OAuth
+- Token refresh (auto-refresh in `get_token()`)
+- Keyring persistence
+
+The SDK **never imports kube-authkit types into its public API**. The adapter
+pattern means kube-authkit can be swapped for another engine without changing
+any SDK consumer code.
+
+## Resolution Priority
+
+When `load_kubernetes_config()` (or `get_kubernetes_client()`) is called:
+
+| Priority | Source | Result |
+|----------|--------|--------|
+| 1 | `client_configuration=` | Pass-through `ApiClient` |
+| 2 | `credentials=` (any `TokenCredentialsBase`) | Wire hook directly |
+| 3 | `token=` | Wrap in `_StaticTokenCredentials` |
+| 4 | `auth_method="oidc"` + OIDC config | kube-authkit strategy via adapter |
+| 5 | `KUBEFLOW_OIDC_*` env vars | kube-authkit client_credentials via adapter |
+| 6 | `KUBEFLOW_TOKEN` env var | Static token |
+| 7 | kubeconfig file | `load_kube_config()` |
+| 8 | In-cluster service account | `load_incluster_config()` |
+
+## Dual-Interface Design
+
+`TokenCredentialsBase` provides two methods for two worlds:
+
+- **`refresh_api_key_hook(config)`** -- Called by the Kubernetes Python client
+  before every API request. Enables transparent token refresh for K8s operations.
+
+- **`get_token() -> str`** -- Returns a valid token string for REST clients
+  (KFP Pipelines, Model Registry, etc.) or any consumer that needs a raw bearer token.
+
+Both methods auto-refresh expired tokens. The SDK resolves credentials once and
+shares the same object across both K8s and REST operations.
+
+## Security
+
+- **Monotonic clock** for token expiry (immune to wall-clock adjustments)
+- **30-second buffer** before actual expiry to avoid races
+- **PKCE** for all browser flows
+- **No secrets in logs** -- `AuthConfig.__repr__` redacts sensitive fields
+- **TLS verification** enabled by default
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `KUBEFLOW_OIDC_ISSUER` | OIDC issuer URL |
+| `KUBEFLOW_OIDC_CLIENT_ID` | OIDC client ID |
+| `KUBEFLOW_OIDC_CLIENT_SECRET` | OIDC client secret |
+| `KUBEFLOW_TOKEN` | Static bearer token |
+| `KUBEFLOW_API_HOST` | Kubernetes API server URL |
+
+Legacy `AUTHKIT_*` variants are also supported for backward compatibility.
+
+## Non-Goals (Current Scope)
+
+- **JWT signature verification** -- the API server validates tokens
+- **Auto-detection factory in the SDK** -- kube-authkit owns auto-detection
+- **OpenShift OAuth in SDK core** -- handled by kube-authkit as a strategy
+- **`KubeflowConfig` distribution object** -- planned for a future release

--- a/kubeflow/common/auth/__init__.py
+++ b/kubeflow/common/auth/__init__.py
@@ -1,0 +1,3 @@
+from kubeflow.common.auth.kube_authkit_bridge import get_kubernetes_client
+
+__all__ = ["get_kubernetes_client"]

--- a/kubeflow/common/auth/__init__.py
+++ b/kubeflow/common/auth/__init__.py
@@ -1,3 +1,29 @@
-from kubeflow.common.auth.kube_authkit_bridge import get_kubernetes_client
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-__all__ = ["get_kubernetes_client"]
+from kubeflow.common.auth.identity import identity_annotations
+from kubeflow.common.auth.kube_authkit_bridge import (
+    get_kubernetes_client,
+    load_kubernetes_config,
+    resolve_credentials,
+)
+from kubeflow.common.auth.types import TokenCredentialsBase
+
+__all__ = [
+    "TokenCredentialsBase",
+    "get_kubernetes_client",
+    "load_kubernetes_config",
+    "resolve_credentials",
+    "identity_annotations",
+]

--- a/kubeflow/common/auth/identity.py
+++ b/kubeflow/common/auth/identity.py
@@ -1,0 +1,74 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Identity helpers for extracting user information from JWT tokens."""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+_ANNOTATION_PREFIX = "kubeflow.org/"
+
+_CLAIM_MAP = {
+    "sub": "user-id",
+    "email": "user-email",
+    "preferred_username": "user-name",
+    "groups": "user-groups",
+}
+
+
+def identity_annotations(token: str) -> dict[str, str]:
+    """Extract Kubernetes annotations from JWT claims.
+
+    Decodes the JWT payload (without signature verification -- the API server
+    already validated the token) and maps standard OIDC claims to
+    ``kubeflow.org/`` annotations suitable for setting on Jobs/Pods.
+
+    Returns an empty dict if the token cannot be decoded.
+    """
+    try:
+        payload = _decode_jwt_payload(token)
+    except Exception:
+        logger.debug("Could not decode JWT payload for identity annotations")
+        return {}
+
+    annotations: dict[str, str] = {}
+    for claim, annotation_suffix in _CLAIM_MAP.items():
+        value = payload.get(claim)
+        if value is None:
+            continue
+        if isinstance(value, list):
+            value = ",".join(str(v) for v in value)
+        annotations[f"{_ANNOTATION_PREFIX}{annotation_suffix}"] = str(value)
+
+    return annotations
+
+
+def _decode_jwt_payload(token: str) -> dict:
+    """Decode JWT payload without verification."""
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise ValueError("Not a valid JWT (expected 3 dot-separated parts)")
+
+    payload_b64 = parts[1]
+    padding = 4 - len(payload_b64) % 4
+    if padding != 4:
+        payload_b64 += "=" * padding
+
+    payload_bytes = base64.urlsafe_b64decode(payload_b64)
+    return json.loads(payload_bytes)

--- a/kubeflow/common/auth/kube_authkit_bridge.py
+++ b/kubeflow/common/auth/kube_authkit_bridge.py
@@ -14,6 +14,10 @@
 
 """Authentication bridge between KubernetesBackendConfig and kube-authkit."""
 
+# Kubeflow backends share KubernetesBackendConfig; kube-authkit expects AuthConfig.
+# This file maps between those shapes and picks a resolution strategy. Token exchange,
+# kubeconfig parsing, and ApiClient construction live in kube-authkit, not here.
+
 import logging
 
 from kubernetes import client
@@ -33,11 +37,22 @@ logger = logging.getLogger(__name__)
 def get_kubernetes_client(cfg: KubernetesBackendConfig) -> client.ApiClient:
     """Build a Kubernetes ApiClient using kube-authkit.
 
-    Resolution order:
-    1. Pre-built client_configuration (escape hatch)
-    2. Explicit auth_method with kube-authkit parameters
-    3. Legacy config_file/context (mapped to kubeconfig with deprecation warning)
-    4. Auto-detection (default)
+    Resolution order (first match wins after the import guard):
+
+    1. **Pre-built ``client_configuration``** — caller already has a
+       ``kubernetes.client.Configuration`` (e.g. custom transport). Returned as
+       ``ApiClient`` without invoking kube-authkit.
+
+    2. **Explicit ``auth_method``** — OIDC, OpenShift token, kubeconfig path,
+       in-cluster, etc. Backend-specific fields are folded into ``AuthConfig``;
+       kube-authkit performs login and builds the client.
+
+    3. **Legacy ``config_file`` / ``context``** — backward compatible with older
+       Kubeflow SDK options. Emits a deprecation log; ``config_file`` is mapped to
+       ``kubeconfig_path``. ``context`` is not forwarded (use kube-authkit-supported
+       mechanisms via ``kubeconfig_path`` / explicit method instead).
+
+    4. **Neither** — ``method="auto"`` so kube-authkit chooses how to authenticate.
 
     Raises:
         ImportError: If kube-authkit is not installed.
@@ -48,10 +63,12 @@ def get_kubernetes_client(cfg: KubernetesBackendConfig) -> client.ApiClient:
             "Install it with: pip install kube-authkit"
         )
 
+    # Escape hatch: skip AuthConfig entirely when the caller owns Configuration.
     if cfg.client_configuration is not None:
         logger.debug("Using provided client_configuration")
         return client.ApiClient(cfg.client_configuration)
 
+    # Common TLS / endpoint hints applied for any kube-authkit path below.
     auth_params: dict = {"verify_ssl": cfg.verify_ssl}
 
     if cfg.k8s_api_host is not None:
@@ -64,6 +81,7 @@ def get_kubernetes_client(cfg: KubernetesBackendConfig) -> client.ApiClient:
     if cfg.auth_method is not None:
         auth_params["method"] = cfg.auth_method
 
+        # OIDC-specific knobs; other methods ignore these keys if present in AuthConfig.
         if cfg.auth_method == "oidc":
             auth_params["oidc_issuer"] = cfg.oidc_issuer
             auth_params["client_id"] = cfg.client_id

--- a/kubeflow/common/auth/kube_authkit_bridge.py
+++ b/kubeflow/common/auth/kube_authkit_bridge.py
@@ -12,20 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Authentication bridge between KubernetesBackendConfig and kube-authkit."""
+"""Authentication bridge between KubernetesBackendConfig and kube-authkit.
 
-# Kubeflow backends share KubernetesBackendConfig; kube-authkit expects AuthConfig.
-# This file maps between those shapes and picks a resolution strategy. Token exchange,
-# kubeconfig parsing, and ApiClient construction live in kube-authkit, not here.
+Provides three public functions:
+
+- ``resolve_credentials`` -- resolves a ``TokenCredentialsBase`` from explicit
+  arguments, kube-authkit strategies, or environment variables.
+- ``load_kubernetes_config`` -- builds a Kubernetes ``ApiClient`` using the
+  resolved credentials, kubeconfig, or in-cluster service account.
+- ``get_kubernetes_client`` -- convenience wrapper that resolves config from
+  ``KubernetesBackendConfig`` and returns an ``ApiClient``.
+"""
+
+from __future__ import annotations
 
 import logging
+import os
 
-from kubernetes import client
+from kubernetes import client, config
 
+from kubeflow.common.auth.types import TokenCredentialsBase
 from kubeflow.common.types import KubernetesBackendConfig
 
 try:
-    from kube_authkit import AuthConfig, get_k8s_client as kube_authkit_get_client
+    from kube_authkit import AuthConfig
+    from kube_authkit import get_k8s_client as kube_authkit_get_client  # noqa: F401
+    from kube_authkit.factory import AuthFactory
 
     KUBE_AUTHKIT_AVAILABLE = True
 except ImportError:
@@ -34,81 +46,329 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-def get_kubernetes_client(cfg: KubernetesBackendConfig) -> client.ApiClient:
-    """Build a Kubernetes ApiClient using kube-authkit.
+class _KubeAuthkitAdapter:
+    """Wraps a kube-authkit ``AuthStrategy`` as a ``TokenCredentialsBase``.
 
-    Resolution order (first match wins after the import guard):
-
-    1. **Pre-built ``client_configuration``** — caller already has a
-       ``kubernetes.client.Configuration`` (e.g. custom transport). Returned as
-       ``ApiClient`` without invoking kube-authkit.
-
-    2. **Explicit ``auth_method``** — OIDC, OpenShift token, kubeconfig path,
-       in-cluster, etc. Backend-specific fields are folded into ``AuthConfig``;
-       kube-authkit performs login and builds the client.
-
-    3. **Legacy ``config_file`` / ``context``** — backward compatible with older
-       Kubeflow SDK options. Emits a deprecation log; ``config_file`` is mapped to
-       ``kubeconfig_path``. ``context`` is not forwarded (use kube-authkit-supported
-       mechanisms via ``kubeconfig_path`` / explicit method instead).
-
-    4. **Neither** — ``method="auto"`` so kube-authkit chooses how to authenticate.
-
-    Raises:
-        ImportError: If kube-authkit is not installed.
+    The adapter delegates ``get_token()`` to the strategy (which, after
+    the kube-authkit alignment PR, auto-refreshes expired tokens).
+    ``refresh_api_key_hook`` updates the K8s ``Configuration`` on every request.
     """
+
+    def __init__(self, strategy) -> None:
+        self._strategy = strategy
+
+    def refresh_api_key_hook(self, config: client.Configuration) -> None:
+        config.api_key["authorization"] = self._strategy.get_token()
+        config.api_key_prefix["authorization"] = "Bearer"
+
+    def get_token(self) -> str:
+        return self._strategy.get_token()
+
+
+class _StaticTokenCredentials:
+    """Wraps a static token string as a ``TokenCredentialsBase``."""
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def refresh_api_key_hook(self, config: client.Configuration) -> None:
+        config.api_key["authorization"] = self._token
+        config.api_key_prefix["authorization"] = "Bearer"
+
+    def get_token(self) -> str:
+        return self._token
+
+
+def resolve_credentials(
+    *,
+    credentials: TokenCredentialsBase | None = None,
+    token: str | None = None,
+    auth_method: str | None = None,
+    oidc_issuer: str | None = None,
+    client_id: str | None = None,
+    client_secret: str | None = None,
+    use_device_flow: bool = False,
+    use_client_credentials: bool = False,
+    oidc_callback_port: int = 8080,
+    scopes: list[str] | None = None,
+    k8s_api_host: str | None = None,
+    use_keyring: bool = False,
+    verify_ssl: bool = True,
+    ca_cert: str | None = None,
+) -> TokenCredentialsBase | None:
+    """Resolve a ``TokenCredentialsBase`` from explicit args or environment.
+
+    Resolution order:
+
+    1. Explicit ``credentials`` object (returned as-is)
+    2. Explicit ``token`` -> wrapped in ``_StaticTokenCredentials``
+    3. Explicit OIDC / OpenShift config -> kube-authkit strategy via adapter
+    4. ``KUBEFLOW_OIDC_*`` env vars -> kube-authkit OIDC strategy via adapter
+    5. ``KUBEFLOW_TOKEN`` env var -> ``_StaticTokenCredentials``
+    6. ``None`` (nothing found -- caller falls back to kubeconfig / in-cluster)
+    """
+    if credentials is not None:
+        return credentials
+
+    if token is not None:
+        return _StaticTokenCredentials(token)
+
+    authkit_creds = _try_authkit_credentials(
+        auth_method=auth_method,
+        oidc_issuer=oidc_issuer,
+        client_id=client_id,
+        client_secret=client_secret,
+        use_device_flow=use_device_flow,
+        use_client_credentials=use_client_credentials,
+        oidc_callback_port=oidc_callback_port,
+        scopes=scopes,
+        k8s_api_host=k8s_api_host,
+        use_keyring=use_keyring,
+        verify_ssl=verify_ssl,
+        ca_cert=ca_cert,
+    )
+    if authkit_creds is not None:
+        return authkit_creds
+
+    env_creds = _try_credentials_from_env(verify_ssl=verify_ssl, ca_cert=ca_cert)
+    if env_creds is not None:
+        return env_creds
+
+    token_env = os.getenv("KUBEFLOW_TOKEN") or os.getenv("AUTHKIT_TOKEN")
+    if token_env:
+        return _StaticTokenCredentials(token_env)
+
+    return None
+
+
+def load_kubernetes_config(
+    *,
+    config_file: str | None = None,
+    context: str | None = None,
+    client_configuration: client.Configuration | None = None,
+    token: str | None = None,
+    server: str | None = None,
+    credentials: TokenCredentialsBase | None = None,
+    auth_method: str | None = None,
+    oidc_issuer: str | None = None,
+    client_id: str | None = None,
+    client_secret: str | None = None,
+    use_device_flow: bool = False,
+    use_client_credentials: bool = False,
+    oidc_callback_port: int = 8080,
+    scopes: list[str] | None = None,
+    k8s_api_host: str | None = None,
+    use_keyring: bool = False,
+    verify_ssl: bool = True,
+    ca_cert: str | None = None,
+) -> client.ApiClient:
+    """Build a Kubernetes ``ApiClient`` with flexible auth options.
+
+    Resolution order:
+
+    1. Explicit ``client_configuration`` (pass-through)
+    2. Pluggable ``credentials`` / ``token`` / OIDC config / env vars
+    3. Kubeconfig file (``config_file`` / ``context`` / default)
+    4. In-cluster service account
+    """
+    if client_configuration is not None:
+        return client.ApiClient(configuration=client_configuration)
+
+    resolved = resolve_credentials(
+        credentials=credentials,
+        token=token,
+        auth_method=auth_method,
+        oidc_issuer=oidc_issuer,
+        client_id=client_id,
+        client_secret=client_secret,
+        use_device_flow=use_device_flow,
+        use_client_credentials=use_client_credentials,
+        oidc_callback_port=oidc_callback_port,
+        scopes=scopes,
+        k8s_api_host=k8s_api_host,
+        use_keyring=use_keyring,
+        verify_ssl=verify_ssl,
+        ca_cert=ca_cert,
+    )
+
+    if resolved is not None:
+        if server is None:
+            server = k8s_api_host or os.getenv("KUBEFLOW_API_HOST") or os.getenv("AUTHKIT_API_HOST")
+        if server is None:
+            raise ValueError(
+                "'server' (or 'k8s_api_host') is required when using credentials or token. "
+                "Set it directly or via KUBEFLOW_API_HOST."
+            )
+        return _build_client_with_credentials(
+            resolved, server, verify_ssl=verify_ssl, ca_cert=ca_cert,
+        )
+
+    try:
+        config.load_kube_config(config_file=config_file, context=context)
+        logger.debug("Loaded kubeconfig")
+        return client.ApiClient()
+    except config.ConfigException:
+        pass
+
+    try:
+        config.load_incluster_config()
+        logger.debug("Loaded in-cluster config")
+        return client.ApiClient()
+    except config.ConfigException:
+        pass
+
+    raise RuntimeError(
+        "Could not configure Kubernetes client. Tried: credentials, "
+        "token, KUBEFLOW_OIDC_* env vars, KUBEFLOW_TOKEN env var, "
+        "kubeconfig, in-cluster config. None succeeded."
+    )
+
+
+def get_kubernetes_client(cfg: KubernetesBackendConfig) -> client.ApiClient:
+    """Build a Kubernetes ApiClient from ``KubernetesBackendConfig``.
+
+    This is the main entry point used by trainer, optimizer, and spark backends.
+    It maps ``KubernetesBackendConfig`` fields to ``load_kubernetes_config`` params.
+    """
+    return load_kubernetes_config(
+        config_file=cfg.config_file,
+        context=cfg.context,
+        client_configuration=cfg.client_configuration,
+        token=cfg.token,
+        server=cfg.server,
+        credentials=cfg.credentials,
+        auth_method=cfg.auth_method,
+        oidc_issuer=cfg.oidc_issuer,
+        client_id=cfg.client_id,
+        client_secret=cfg.client_secret,
+        use_device_flow=cfg.use_device_flow,
+        use_client_credentials=cfg.use_client_credentials,
+        oidc_callback_port=cfg.oidc_callback_port,
+        scopes=cfg.scopes,
+        k8s_api_host=cfg.k8s_api_host,
+        use_keyring=cfg.use_keyring,
+        verify_ssl=cfg.verify_ssl,
+        ca_cert=cfg.ca_cert,
+    )
+
+
+def _build_client_with_credentials(
+    credentials: TokenCredentialsBase,
+    server: str,
+    *,
+    verify_ssl: bool = True,
+    ca_cert: str | None = None,
+) -> client.ApiClient:
+    k8s_config = client.Configuration()
+    k8s_config.host = server
+    k8s_config.verify_ssl = verify_ssl
+    if ca_cert:
+        k8s_config.ssl_ca_cert = ca_cert
+
+    k8s_config.api_key["authorization"] = "placeholder"
+    k8s_config.api_key_prefix["authorization"] = "Bearer"
+    k8s_config.refresh_api_key_hook = credentials.refresh_api_key_hook
+
+    return client.ApiClient(configuration=k8s_config)
+
+
+def _try_authkit_credentials(
+    *,
+    auth_method: str | None,
+    oidc_issuer: str | None,
+    client_id: str | None,
+    client_secret: str | None,
+    use_device_flow: bool,
+    use_client_credentials: bool,
+    oidc_callback_port: int,
+    scopes: list[str] | None,
+    k8s_api_host: str | None,
+    use_keyring: bool,
+    verify_ssl: bool,
+    ca_cert: str | None,
+) -> TokenCredentialsBase | None:
+    """Build credentials via kube-authkit strategy if OIDC/OpenShift config is present."""
     if not KUBE_AUTHKIT_AVAILABLE:
-        raise ImportError(
-            "kube-authkit is required for authentication. "
-            "Install it with: pip install kube-authkit"
+        return None
+
+    if auth_method not in ("oidc", "openshift"):
+        return None
+
+    auth_params: dict = {
+        "method": auth_method,
+        "verify_ssl": verify_ssl,
+    }
+
+    if k8s_api_host is not None:
+        auth_params["k8s_api_host"] = k8s_api_host
+    if ca_cert is not None:
+        auth_params["ca_cert"] = ca_cert
+
+    if auth_method == "oidc":
+        if not oidc_issuer or not client_id:
+            return None
+        auth_params["oidc_issuer"] = oidc_issuer
+        auth_params["client_id"] = client_id
+        if client_secret is not None:
+            auth_params["client_secret"] = client_secret
+        auth_params["use_device_flow"] = use_device_flow
+        auth_params["use_client_credentials"] = use_client_credentials
+        auth_params["oidc_callback_port"] = oidc_callback_port
+        if scopes is not None:
+            auth_params["scopes"] = scopes
+
+    auth_params["use_keyring"] = use_keyring
+
+    try:
+        auth_config = AuthConfig(**auth_params)
+        factory = AuthFactory(auth_config)
+        strategy = factory.get_strategy()
+        strategy.authenticate()
+        logger.debug("Authenticated via kube-authkit %s strategy", auth_method)
+        return _KubeAuthkitAdapter(strategy)
+    except Exception:
+        logger.debug("kube-authkit %s strategy failed", auth_method, exc_info=True)
+        return None
+
+
+def _try_credentials_from_env(
+    *, verify_ssl: bool = True, ca_cert: str | None = None,
+) -> TokenCredentialsBase | None:
+    """Attempt to build OIDC credentials from environment variables."""
+    if not KUBE_AUTHKIT_AVAILABLE:
+        return None
+
+    issuer = os.getenv("KUBEFLOW_OIDC_ISSUER") or os.getenv("AUTHKIT_OIDC_ISSUER")
+    cid = os.getenv("KUBEFLOW_OIDC_CLIENT_ID") or os.getenv("AUTHKIT_CLIENT_ID")
+    if not issuer or not cid:
+        return None
+
+    secret = os.getenv("KUBEFLOW_OIDC_CLIENT_SECRET") or os.getenv("AUTHKIT_CLIENT_SECRET")
+    if not secret:
+        logger.info(
+            "OIDC issuer and client ID found in env but client secret is missing -- "
+            "skipping OIDC env var auth."
         )
+        return None
 
-    # Escape hatch: skip AuthConfig entirely when the caller owns Configuration.
-    if cfg.client_configuration is not None:
-        logger.debug("Using provided client_configuration")
-        return client.ApiClient(cfg.client_configuration)
+    host = os.getenv("KUBEFLOW_API_HOST") or os.getenv("AUTHKIT_API_HOST")
 
-    # Common TLS / endpoint hints applied for any kube-authkit path below.
-    auth_params: dict = {"verify_ssl": cfg.verify_ssl}
-
-    if cfg.k8s_api_host is not None:
-        auth_params["k8s_api_host"] = cfg.k8s_api_host
-    if cfg.kubeconfig_path is not None:
-        auth_params["kubeconfig_path"] = cfg.kubeconfig_path
-    if cfg.ca_cert is not None:
-        auth_params["ca_cert"] = cfg.ca_cert
-
-    if cfg.auth_method is not None:
-        auth_params["method"] = cfg.auth_method
-
-        # OIDC-specific knobs; other methods ignore these keys if present in AuthConfig.
-        if cfg.auth_method == "oidc":
-            auth_params["oidc_issuer"] = cfg.oidc_issuer
-            auth_params["client_id"] = cfg.client_id
-            auth_params["client_secret"] = cfg.client_secret
-            auth_params["use_device_flow"] = cfg.use_device_flow
-            auth_params["oidc_callback_port"] = cfg.oidc_callback_port
-            if cfg.scopes is not None:
-                auth_params["scopes"] = cfg.scopes
-
-        if cfg.auth_method == "openshift" and cfg.token is not None:
-            auth_params["token"] = cfg.token
-
-        auth_params["use_keyring"] = cfg.use_keyring
-
-    elif cfg.config_file is not None or cfg.context is not None:
-        logger.warning(
-            "The 'config_file' and 'context' parameters are deprecated. "
-            "Use 'kubeconfig_path' and 'auth_method=\"kubeconfig\"' instead."
+    try:
+        auth_config = AuthConfig(
+            method="oidc",
+            oidc_issuer=issuer,
+            client_id=cid,
+            client_secret=secret,
+            use_client_credentials=True,
+            verify_ssl=verify_ssl,
+            **({"ca_cert": ca_cert} if ca_cert else {}),
+            **({"k8s_api_host": host} if host else {}),
         )
-        auth_params["method"] = "kubeconfig"
-        if cfg.config_file is not None:
-            auth_params["kubeconfig_path"] = cfg.config_file
-
-    else:
-        auth_params["method"] = "auto"
-
-    auth_config = AuthConfig(**auth_params)
-    api_client = kube_authkit_get_client(auth_config)
-    logger.debug("Authenticated via kube-authkit")
-    return api_client
+        factory = AuthFactory(auth_config)
+        strategy = factory.get_strategy()
+        strategy.authenticate()
+        logger.debug("Authenticated via kube-authkit OIDC from env vars")
+        return _KubeAuthkitAdapter(strategy)
+    except Exception:
+        logger.debug("kube-authkit OIDC from env vars failed", exc_info=True)
+        return None

--- a/kubeflow/common/auth/kube_authkit_bridge.py
+++ b/kubeflow/common/auth/kube_authkit_bridge.py
@@ -1,0 +1,96 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Authentication bridge between KubernetesBackendConfig and kube-authkit."""
+
+import logging
+
+from kubernetes import client
+
+from kubeflow.common.types import KubernetesBackendConfig
+
+try:
+    from kube_authkit import AuthConfig, get_k8s_client as kube_authkit_get_client
+
+    KUBE_AUTHKIT_AVAILABLE = True
+except ImportError:
+    KUBE_AUTHKIT_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
+
+
+def get_kubernetes_client(cfg: KubernetesBackendConfig) -> client.ApiClient:
+    """Build a Kubernetes ApiClient using kube-authkit.
+
+    Resolution order:
+    1. Pre-built client_configuration (escape hatch)
+    2. Explicit auth_method with kube-authkit parameters
+    3. Legacy config_file/context (mapped to kubeconfig with deprecation warning)
+    4. Auto-detection (default)
+
+    Raises:
+        ImportError: If kube-authkit is not installed.
+    """
+    if not KUBE_AUTHKIT_AVAILABLE:
+        raise ImportError(
+            "kube-authkit is required for authentication. "
+            "Install it with: pip install kube-authkit"
+        )
+
+    if cfg.client_configuration is not None:
+        logger.debug("Using provided client_configuration")
+        return client.ApiClient(cfg.client_configuration)
+
+    auth_params: dict = {"verify_ssl": cfg.verify_ssl}
+
+    if cfg.k8s_api_host is not None:
+        auth_params["k8s_api_host"] = cfg.k8s_api_host
+    if cfg.kubeconfig_path is not None:
+        auth_params["kubeconfig_path"] = cfg.kubeconfig_path
+    if cfg.ca_cert is not None:
+        auth_params["ca_cert"] = cfg.ca_cert
+
+    if cfg.auth_method is not None:
+        auth_params["method"] = cfg.auth_method
+
+        if cfg.auth_method == "oidc":
+            auth_params["oidc_issuer"] = cfg.oidc_issuer
+            auth_params["client_id"] = cfg.client_id
+            auth_params["client_secret"] = cfg.client_secret
+            auth_params["use_device_flow"] = cfg.use_device_flow
+            auth_params["oidc_callback_port"] = cfg.oidc_callback_port
+            if cfg.scopes is not None:
+                auth_params["scopes"] = cfg.scopes
+
+        if cfg.auth_method == "openshift" and cfg.token is not None:
+            auth_params["token"] = cfg.token
+
+        auth_params["use_keyring"] = cfg.use_keyring
+
+    elif cfg.config_file is not None or cfg.context is not None:
+        logger.warning(
+            "The 'config_file' and 'context' parameters are deprecated. "
+            "Use 'kubeconfig_path' and 'auth_method=\"kubeconfig\"' instead."
+        )
+        auth_params["method"] = "kubeconfig"
+        if cfg.config_file is not None:
+            auth_params["kubeconfig_path"] = cfg.config_file
+
+    else:
+        auth_params["method"] = "auto"
+
+    auth_config = AuthConfig(**auth_params)
+    api_client = kube_authkit_get_client(auth_config)
+    logger.debug("Authenticated via kube-authkit")
+    return api_client

--- a/kubeflow/common/auth/kube_authkit_bridge_test.py
+++ b/kubeflow/common/auth/kube_authkit_bridge_test.py
@@ -12,255 +12,334 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for :mod:`kubeflow.common.auth.kube_authkit_bridge`.
-
-``AuthConfig`` and ``get_k8s_client`` are patched on the bridge module so tests
-do not depend on kube-authkit behavior or installation.
-"""
+"""Tests for kubeflow.common.auth — bridge, resolution, adapter, identity."""
 
 from __future__ import annotations
 
-import logging
+import base64
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
 from kubernetes import client
 
+from kubeflow.common.auth.identity import identity_annotations
+from kubeflow.common.auth.kube_authkit_bridge import (
+    _KubeAuthkitAdapter,
+    _StaticTokenCredentials,
+    _build_client_with_credentials,
+    get_kubernetes_client,
+    load_kubernetes_config,
+    resolve_credentials,
+)
+from kubeflow.common.auth.types import TokenCredentialsBase
 from kubeflow.common.types import KubernetesBackendConfig
 
 
-@pytest.fixture
-def bridge_module():
-    import kubeflow.common.auth.kube_authkit_bridge as mod
+# ---------------------------------------------------------------------------
+# TokenCredentialsBase protocol compliance
+# ---------------------------------------------------------------------------
 
-    return mod
+class TestTokenCredentialsBaseProtocol:
+    def test_static_token_satisfies_protocol(self):
+        creds = _StaticTokenCredentials("tok")
+        assert isinstance(creds, TokenCredentialsBase)
 
+    def test_adapter_satisfies_protocol(self):
+        strategy = MagicMock()
+        strategy.get_token.return_value = "tok"
+        adapter = _KubeAuthkitAdapter(strategy)
+        assert isinstance(adapter, TokenCredentialsBase)
 
-@pytest.fixture
-def authkit_available(bridge_module):
-    """Force the bridge to behave as if kube-authkit were importable."""
-    with patch.object(bridge_module, "KUBE_AUTHKIT_AVAILABLE", True):
-        yield bridge_module
-
-
-def test_prebuilt_client_configuration_returns_api_client_directly(
-    authkit_available, bridge_module
-):
-    """When ``client_configuration`` is set, return ``ApiClient`` without calling kube-authkit."""
-    configuration = client.Configuration()
-    configuration.host = "https://example.test:6443"
-    cfg = KubernetesBackendConfig(client_configuration=configuration)
-
-    with patch.object(bridge_module, "kube_authkit_get_client") as mock_get_client:
-        with patch.object(bridge_module, "AuthConfig") as mock_auth_config:
-            result = bridge_module.get_kubernetes_client(cfg)
-
-    assert isinstance(result, client.ApiClient)
-    mock_get_client.assert_not_called()
-    mock_auth_config.assert_not_called()
+    def test_custom_object_satisfies_protocol(self):
+        class MyCreds:
+            def refresh_api_key_hook(self, config):
+                pass
+            def get_token(self):
+                return "x"
+        assert isinstance(MyCreds(), TokenCredentialsBase)
 
 
-def test_oidc_auth_method_maps_to_auth_config(authkit_available, bridge_module):
-    cfg = KubernetesBackendConfig(
-        auth_method="oidc",
-        oidc_issuer="https://issuer.example",
-        client_id="my-client",
-        client_secret="secret",
-        scopes=["openid", "profile"],
-        use_device_flow=True,
-        oidc_callback_port=9000,
-        use_keyring=True,
-        verify_ssl=False,
-        k8s_api_host="https://api.example:6443",
-        ca_cert="/tmp/ca.pem",
-    )
-    fake_client = MagicMock()
-    with patch.object(bridge_module, "kube_authkit_get_client", return_value=fake_client) as mock_get:
-        with patch.object(bridge_module, "AuthConfig") as mock_auth_config:
-            out = bridge_module.get_kubernetes_client(cfg)
+# ---------------------------------------------------------------------------
+# _StaticTokenCredentials
+# ---------------------------------------------------------------------------
 
-    mock_auth_config.assert_called_once_with(
-        verify_ssl=False,
-        k8s_api_host="https://api.example:6443",
-        ca_cert="/tmp/ca.pem",
-        method="oidc",
-        oidc_issuer="https://issuer.example",
-        client_id="my-client",
-        client_secret="secret",
-        use_device_flow=True,
-        oidc_callback_port=9000,
-        scopes=["openid", "profile"],
-        use_keyring=True,
-    )
-    mock_get.assert_called_once_with(mock_auth_config.return_value)
-    assert out is fake_client
+class TestStaticTokenCredentials:
+    def test_get_token(self):
+        creds = _StaticTokenCredentials("my-token")
+        assert creds.get_token() == "my-token"
+
+    def test_refresh_api_key_hook_updates_config(self):
+        creds = _StaticTokenCredentials("my-token")
+        cfg = client.Configuration()
+        creds.refresh_api_key_hook(cfg)
+        assert cfg.api_key["authorization"] == "my-token"
+        assert cfg.api_key_prefix["authorization"] == "Bearer"
 
 
-def test_openshift_auth_method_passes_token(authkit_available, bridge_module):
-    cfg = KubernetesBackendConfig(
-        auth_method="openshift",
-        token="sha256~deadbeef",
-        use_keyring=False,
-    )
-    with patch.object(bridge_module, "kube_authkit_get_client", return_value=MagicMock()) as mock_get:
-        with patch.object(bridge_module, "AuthConfig") as mock_auth_config:
-            bridge_module.get_kubernetes_client(cfg)
+# ---------------------------------------------------------------------------
+# _KubeAuthkitAdapter
+# ---------------------------------------------------------------------------
 
-    mock_auth_config.assert_called_once_with(
-        verify_ssl=True,
-        method="openshift",
-        token="sha256~deadbeef",
-        use_keyring=False,
-    )
-    mock_get.assert_called_once()
+class TestKubeAuthkitAdapter:
+    def test_get_token_delegates(self):
+        strategy = MagicMock()
+        strategy.get_token.return_value = "delegated-tok"
+        adapter = _KubeAuthkitAdapter(strategy)
+        assert adapter.get_token() == "delegated-tok"
+        strategy.get_token.assert_called_once()
 
-
-def test_legacy_config_file_maps_to_kubeconfig_and_warns(
-    authkit_available, bridge_module, caplog
-):
-    caplog.set_level(logging.WARNING)
-    cfg = KubernetesBackendConfig(config_file="/legacy/kubeconfig")
-
-    with patch.object(bridge_module, "kube_authkit_get_client", return_value=MagicMock()):
-        with patch.object(bridge_module, "AuthConfig") as mock_auth_config:
-            bridge_module.get_kubernetes_client(cfg)
-
-    mock_auth_config.assert_called_once_with(
-        verify_ssl=True,
-        method="kubeconfig",
-        kubeconfig_path="/legacy/kubeconfig",
-    )
-    assert any("deprecated" in r.message.lower() for r in caplog.records)
+    def test_refresh_api_key_hook_delegates(self):
+        strategy = MagicMock()
+        strategy.get_token.return_value = "refreshed-tok"
+        adapter = _KubeAuthkitAdapter(strategy)
+        cfg = client.Configuration()
+        adapter.refresh_api_key_hook(cfg)
+        assert cfg.api_key["authorization"] == "refreshed-tok"
+        assert cfg.api_key_prefix["authorization"] == "Bearer"
 
 
-def test_legacy_context_only_warns_and_sets_kubeconfig_method(
-    authkit_available, bridge_module, caplog
-):
-    caplog.set_level(logging.WARNING)
-    cfg = KubernetesBackendConfig(context="my-context")
+# ---------------------------------------------------------------------------
+# _build_client_with_credentials
+# ---------------------------------------------------------------------------
 
-    with patch.object(bridge_module, "kube_authkit_get_client", return_value=MagicMock()):
-        with patch.object(bridge_module, "AuthConfig") as mock_auth_config:
-            bridge_module.get_kubernetes_client(cfg)
+class TestBuildClientWithCredentials:
+    def test_wires_hook_and_server(self):
+        creds = _StaticTokenCredentials("tok")
+        api_client = _build_client_with_credentials(
+            creds, "https://api.test:6443"
+        )
+        assert isinstance(api_client, client.ApiClient)
+        assert api_client.configuration.host == "https://api.test:6443"
+        assert api_client.configuration.refresh_api_key_hook is not None
+        # Verify the hook actually works by calling it
+        api_client.configuration.refresh_api_key_hook(api_client.configuration)
+        assert api_client.configuration.api_key["authorization"] == "tok"
 
-    mock_auth_config.assert_called_once_with(verify_ssl=True, method="kubeconfig")
-    assert any("deprecated" in r.message.lower() for r in caplog.records)
-
-
-def test_auto_detection_when_no_explicit_auth_params(authkit_available, bridge_module):
-    cfg = KubernetesBackendConfig()
-
-    with patch.object(bridge_module, "kube_authkit_get_client", return_value=MagicMock()):
-        with patch.object(bridge_module, "AuthConfig") as mock_auth_config:
-            bridge_module.get_kubernetes_client(cfg)
-
-    mock_auth_config.assert_called_once_with(verify_ssl=True, method="auto")
-
-
-def test_raises_import_error_when_kube_authkit_unavailable(bridge_module):
-    cfg = KubernetesBackendConfig()
-
-    with patch.object(bridge_module, "KUBE_AUTHKIT_AVAILABLE", False):
-        with pytest.raises(ImportError, match="kube-authkit"):
-            bridge_module.get_kubernetes_client(cfg)
+    def test_ca_cert_and_verify_ssl(self):
+        creds = _StaticTokenCredentials("tok")
+        api_client = _build_client_with_credentials(
+            creds, "https://api.test:6443",
+            verify_ssl=False, ca_cert="/tmp/ca.pem",
+        )
+        assert api_client.configuration.verify_ssl is False
+        assert api_client.configuration.ssl_ca_cert == "/tmp/ca.pem"
 
 
-def test_kubeconfig_path_and_verify_ssl_propagate(authkit_available, bridge_module):
-    cfg = KubernetesBackendConfig(
-        auth_method="kubeconfig",
-        kubeconfig_path="/home/user/.kube/config",
-        verify_ssl=False,
-        k8s_api_host="https://cluster.local",
-        ca_cert="/etc/pki/ca.pem",
-    )
+# ---------------------------------------------------------------------------
+# resolve_credentials
+# ---------------------------------------------------------------------------
 
-    with patch.object(bridge_module, "kube_authkit_get_client", return_value=MagicMock()):
-        with patch.object(bridge_module, "AuthConfig") as mock_auth_config:
-            bridge_module.get_kubernetes_client(cfg)
+class TestResolveCredentials:
+    def test_explicit_credentials_returned_as_is(self):
+        creds = _StaticTokenCredentials("explicit")
+        result = resolve_credentials(credentials=creds)
+        assert result is creds
 
-    mock_auth_config.assert_called_once_with(
-        verify_ssl=False,
-        k8s_api_host="https://cluster.local",
-        kubeconfig_path="/home/user/.kube/config",
-        ca_cert="/etc/pki/ca.pem",
-        method="kubeconfig",
-        use_keyring=False,
-    )
+    def test_explicit_token_wrapped(self):
+        result = resolve_credentials(token="my-token")
+        assert isinstance(result, _StaticTokenCredentials)
+        assert result.get_token() == "my-token"
 
+    def test_credentials_takes_priority_over_token(self):
+        creds = _StaticTokenCredentials("creds")
+        result = resolve_credentials(credentials=creds, token="token")
+        assert result is creds
 
-def test_oidc_optional_scopes_omitted_when_none(authkit_available, bridge_module):
-    cfg = KubernetesBackendConfig(
-        auth_method="oidc",
-        oidc_issuer="https://issuer",
-        client_id="id",
-        scopes=None,
-    )
+    @patch.dict("os.environ", {"KUBEFLOW_TOKEN": "env-tok"}, clear=False)
+    def test_kubeflow_token_env_fallback(self):
+        result = resolve_credentials()
+        assert result is not None
+        assert result.get_token() == "env-tok"
 
-    with patch.object(bridge_module, "kube_authkit_get_client", return_value=MagicMock()):
-        with patch.object(bridge_module, "AuthConfig") as mock_auth_config:
-            bridge_module.get_kubernetes_client(cfg)
+    @patch.dict("os.environ", {"AUTHKIT_TOKEN": "authkit-tok"}, clear=False)
+    def test_authkit_token_env_fallback(self):
+        result = resolve_credentials()
+        assert result is not None
+        assert result.get_token() == "authkit-tok"
 
-    _, kwargs = mock_auth_config.call_args
-    assert "scopes" not in kwargs
-
-
-def test_explicit_kubeconfig_does_not_emit_deprecation_warning(
-    authkit_available, bridge_module, caplog
-):
-    caplog.set_level(logging.WARNING)
-    cfg = KubernetesBackendConfig(
-        auth_method="kubeconfig",
-        kubeconfig_path="/path/config",
-    )
-
-    with patch.object(bridge_module, "kube_authkit_get_client", return_value=MagicMock()):
-        with patch.object(bridge_module, "AuthConfig"):
-            bridge_module.get_kubernetes_client(cfg)
-
-    assert not any("deprecated" in r.message.lower() for r in caplog.records)
+    @patch.dict("os.environ", {}, clear=True)
+    def test_returns_none_when_nothing_available(self):
+        result = resolve_credentials()
+        assert result is None
 
 
-def test_kubeconfig_path_passed_with_auto_method(authkit_available, bridge_module):
-    """``kubeconfig_path`` without ``auth_method`` still reaches kube-authkit on the auto path."""
-    cfg = KubernetesBackendConfig(kubeconfig_path="/x/kubeconfig")
+# ---------------------------------------------------------------------------
+# load_kubernetes_config
+# ---------------------------------------------------------------------------
 
-    with patch.object(bridge_module, "kube_authkit_get_client", return_value=MagicMock()):
-        with patch.object(bridge_module, "AuthConfig") as mock_auth_config:
-            bridge_module.get_kubernetes_client(cfg)
+class TestLoadKubernetesConfig:
+    def test_client_configuration_passthrough(self):
+        cfg = client.Configuration()
+        cfg.host = "https://example.test:6443"
+        result = load_kubernetes_config(client_configuration=cfg)
+        assert isinstance(result, client.ApiClient)
+        assert result.configuration.host == "https://example.test:6443"
 
-    mock_auth_config.assert_called_once_with(
-        verify_ssl=True,
-        kubeconfig_path="/x/kubeconfig",
-        method="auto",
-    )
+    def test_token_with_server(self):
+        result = load_kubernetes_config(
+            token="my-token", server="https://api.test:6443"
+        )
+        assert isinstance(result, client.ApiClient)
+        assert result.configuration.host == "https://api.test:6443"
+        assert result.configuration.refresh_api_key_hook is not None
+
+    def test_token_without_server_raises(self):
+        with pytest.raises(ValueError, match="server"):
+            load_kubernetes_config(token="tok")
+
+    def test_credentials_with_server(self):
+        creds = _StaticTokenCredentials("creds-tok")
+        result = load_kubernetes_config(
+            credentials=creds, server="https://api.test:6443"
+        )
+        assert isinstance(result, client.ApiClient)
+        assert result.configuration.refresh_api_key_hook is not None
+        result.configuration.refresh_api_key_hook(result.configuration)
+        assert result.configuration.api_key["authorization"] == "creds-tok"
+
+    @patch("kubeflow.common.auth.kube_authkit_bridge.config.load_kube_config")
+    def test_kubeconfig_fallback(self, mock_load):
+        mock_load.return_value = None
+        result = load_kubernetes_config(config_file="/path/config")
+        assert isinstance(result, client.ApiClient)
+        mock_load.assert_called_once_with(config_file="/path/config", context=None)
+
+    @patch("kubeflow.common.auth.kube_authkit_bridge.config.load_kube_config")
+    @patch("kubeflow.common.auth.kube_authkit_bridge.config.load_incluster_config")
+    def test_incluster_fallback(self, mock_incluster, mock_kube):
+        from kubernetes.config import ConfigException
+        mock_kube.side_effect = ConfigException("no config")
+        mock_incluster.return_value = None
+        result = load_kubernetes_config()
+        assert isinstance(result, client.ApiClient)
+        mock_incluster.assert_called_once()
+
+    @patch("kubeflow.common.auth.kube_authkit_bridge.config.load_kube_config")
+    @patch("kubeflow.common.auth.kube_authkit_bridge.config.load_incluster_config")
+    def test_all_fallbacks_fail_raises_runtime_error(self, mock_incluster, mock_kube):
+        from kubernetes.config import ConfigException
+        mock_kube.side_effect = ConfigException("no config")
+        mock_incluster.side_effect = ConfigException("not in cluster")
+        with pytest.raises(RuntimeError, match="Could not configure"):
+            load_kubernetes_config()
 
 
-def test_incluster_auth_method_maps_common_fields(authkit_available, bridge_module):
-    cfg = KubernetesBackendConfig(
-        auth_method="incluster",
-        use_keyring=True,
-        verify_ssl=False,
-        k8s_api_host="https://kubernetes.default",
-    )
+# ---------------------------------------------------------------------------
+# get_kubernetes_client
+# ---------------------------------------------------------------------------
 
-    with patch.object(bridge_module, "kube_authkit_get_client", return_value=MagicMock()):
-        with patch.object(bridge_module, "AuthConfig") as mock_auth_config:
-            bridge_module.get_kubernetes_client(cfg)
+class TestGetKubernetesClient:
+    def test_prebuilt_client_configuration(self):
+        cfg_obj = client.Configuration()
+        cfg_obj.host = "https://example:6443"
+        backend = KubernetesBackendConfig(client_configuration=cfg_obj)
+        result = get_kubernetes_client(backend)
+        assert isinstance(result, client.ApiClient)
 
-    mock_auth_config.assert_called_once_with(
-        verify_ssl=False,
-        k8s_api_host="https://kubernetes.default",
-        method="incluster",
-        use_keyring=True,
-    )
+    def test_token_and_server(self):
+        backend = KubernetesBackendConfig(
+            token="tok", server="https://api.test:6443"
+        )
+        result = get_kubernetes_client(backend)
+        assert isinstance(result, client.ApiClient)
+
+    def test_credentials_field(self):
+        creds = _StaticTokenCredentials("creds-tok")
+        backend = KubernetesBackendConfig(
+            credentials=creds, server="https://api.test:6443"
+        )
+        result = get_kubernetes_client(backend)
+        assert isinstance(result, client.ApiClient)
+        assert result.configuration.refresh_api_key_hook is not None
+        result.configuration.refresh_api_key_hook(result.configuration)
+        assert result.configuration.api_key["authorization"] == "creds-tok"
+
+    @patch("kubeflow.common.auth.kube_authkit_bridge.config.load_kube_config")
+    def test_legacy_config_file(self, mock_load):
+        mock_load.return_value = None
+        backend = KubernetesBackendConfig(config_file="/path/config")
+        result = get_kubernetes_client(backend)
+        assert isinstance(result, client.ApiClient)
+
+    @patch("kubeflow.common.auth.kube_authkit_bridge.config.load_kube_config")
+    def test_default_auto_detection(self, mock_load):
+        mock_load.return_value = None
+        backend = KubernetesBackendConfig()
+        result = get_kubernetes_client(backend)
+        assert isinstance(result, client.ApiClient)
 
 
-def test_openshift_without_token_omits_token_key(authkit_available, bridge_module):
-    cfg = KubernetesBackendConfig(auth_method="openshift", token=None)
+# ---------------------------------------------------------------------------
+# identity_annotations
+# ---------------------------------------------------------------------------
 
-    with patch.object(bridge_module, "kube_authkit_get_client", return_value=MagicMock()):
-        with patch.object(bridge_module, "AuthConfig") as mock_auth_config:
-            bridge_module.get_kubernetes_client(cfg)
+def _make_jwt(payload: dict) -> str:
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256"}).encode()).rstrip(b"=")
+    body = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=")
+    sig = base64.urlsafe_b64encode(b"fake-signature").rstrip(b"=")
+    return f"{header.decode()}.{body.decode()}.{sig.decode()}"
 
-    _, kwargs = mock_auth_config.call_args
-    assert "token" not in kwargs
+
+class TestIdentityAnnotations:
+    def test_full_claims(self):
+        token = _make_jwt({
+            "sub": "user-123",
+            "email": "user@example.com",
+            "preferred_username": "jdoe",
+            "groups": ["team-a", "team-b"],
+        })
+        result = identity_annotations(token)
+        assert result["kubeflow.org/user-id"] == "user-123"
+        assert result["kubeflow.org/user-email"] == "user@example.com"
+        assert result["kubeflow.org/user-name"] == "jdoe"
+        assert result["kubeflow.org/user-groups"] == "team-a,team-b"
+
+    def test_partial_claims(self):
+        token = _make_jwt({"sub": "user-456"})
+        result = identity_annotations(token)
+        assert result == {"kubeflow.org/user-id": "user-456"}
+
+    def test_empty_payload(self):
+        token = _make_jwt({})
+        result = identity_annotations(token)
+        assert result == {}
+
+    def test_invalid_token_returns_empty(self):
+        result = identity_annotations("not-a-jwt")
+        assert result == {}
+
+    def test_groups_as_single_string(self):
+        token = _make_jwt({"groups": ["admins"]})
+        result = identity_annotations(token)
+        assert result["kubeflow.org/user-groups"] == "admins"
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility
+# ---------------------------------------------------------------------------
+
+class TestBackwardCompatibility:
+    """Ensure old config_file / context patterns still work."""
+
+    @patch("kubeflow.common.auth.kube_authkit_bridge.config.load_kube_config")
+    def test_config_file_and_context(self, mock_load):
+        mock_load.return_value = None
+        backend = KubernetesBackendConfig(
+            config_file="/legacy/config", context="my-ctx"
+        )
+        result = get_kubernetes_client(backend)
+        assert isinstance(result, client.ApiClient)
+        mock_load.assert_called_once_with(
+            config_file="/legacy/config", context="my-ctx"
+        )
+
+    def test_verify_ssl_default_true(self):
+        backend = KubernetesBackendConfig()
+        assert backend.verify_ssl is True
+
+    def test_new_fields_default_none(self):
+        backend = KubernetesBackendConfig()
+        assert backend.credentials is None
+        assert backend.server is None
+        assert backend.use_client_credentials is False

--- a/kubeflow/common/auth/kube_authkit_bridge_test.py
+++ b/kubeflow/common/auth/kube_authkit_bridge_test.py
@@ -1,0 +1,266 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for :mod:`kubeflow.common.auth.kube_authkit_bridge`.
+
+``AuthConfig`` and ``get_k8s_client`` are patched on the bridge module so tests
+do not depend on kube-authkit behavior or installation.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+from kubernetes import client
+
+from kubeflow.common.types import KubernetesBackendConfig
+
+
+@pytest.fixture
+def bridge_module():
+    import kubeflow.common.auth.kube_authkit_bridge as mod
+
+    return mod
+
+
+@pytest.fixture
+def authkit_available(bridge_module):
+    """Force the bridge to behave as if kube-authkit were importable."""
+    with patch.object(bridge_module, "KUBE_AUTHKIT_AVAILABLE", True):
+        yield bridge_module
+
+
+def test_prebuilt_client_configuration_returns_api_client_directly(
+    authkit_available, bridge_module
+):
+    """When ``client_configuration`` is set, return ``ApiClient`` without calling kube-authkit."""
+    configuration = client.Configuration()
+    configuration.host = "https://example.test:6443"
+    cfg = KubernetesBackendConfig(client_configuration=configuration)
+
+    with patch.object(bridge_module, "kube_authkit_get_client") as mock_get_client:
+        with patch.object(bridge_module, "AuthConfig") as mock_auth_config:
+            result = bridge_module.get_kubernetes_client(cfg)
+
+    assert isinstance(result, client.ApiClient)
+    mock_get_client.assert_not_called()
+    mock_auth_config.assert_not_called()
+
+
+def test_oidc_auth_method_maps_to_auth_config(authkit_available, bridge_module):
+    cfg = KubernetesBackendConfig(
+        auth_method="oidc",
+        oidc_issuer="https://issuer.example",
+        client_id="my-client",
+        client_secret="secret",
+        scopes=["openid", "profile"],
+        use_device_flow=True,
+        oidc_callback_port=9000,
+        use_keyring=True,
+        verify_ssl=False,
+        k8s_api_host="https://api.example:6443",
+        ca_cert="/tmp/ca.pem",
+    )
+    fake_client = MagicMock()
+    with patch.object(bridge_module, "kube_authkit_get_client", return_value=fake_client) as mock_get:
+        with patch.object(bridge_module, "AuthConfig") as mock_auth_config:
+            out = bridge_module.get_kubernetes_client(cfg)
+
+    mock_auth_config.assert_called_once_with(
+        verify_ssl=False,
+        k8s_api_host="https://api.example:6443",
+        ca_cert="/tmp/ca.pem",
+        method="oidc",
+        oidc_issuer="https://issuer.example",
+        client_id="my-client",
+        client_secret="secret",
+        use_device_flow=True,
+        oidc_callback_port=9000,
+        scopes=["openid", "profile"],
+        use_keyring=True,
+    )
+    mock_get.assert_called_once_with(mock_auth_config.return_value)
+    assert out is fake_client
+
+
+def test_openshift_auth_method_passes_token(authkit_available, bridge_module):
+    cfg = KubernetesBackendConfig(
+        auth_method="openshift",
+        token="sha256~deadbeef",
+        use_keyring=False,
+    )
+    with patch.object(bridge_module, "kube_authkit_get_client", return_value=MagicMock()) as mock_get:
+        with patch.object(bridge_module, "AuthConfig") as mock_auth_config:
+            bridge_module.get_kubernetes_client(cfg)
+
+    mock_auth_config.assert_called_once_with(
+        verify_ssl=True,
+        method="openshift",
+        token="sha256~deadbeef",
+        use_keyring=False,
+    )
+    mock_get.assert_called_once()
+
+
+def test_legacy_config_file_maps_to_kubeconfig_and_warns(
+    authkit_available, bridge_module, caplog
+):
+    caplog.set_level(logging.WARNING)
+    cfg = KubernetesBackendConfig(config_file="/legacy/kubeconfig")
+
+    with patch.object(bridge_module, "kube_authkit_get_client", return_value=MagicMock()):
+        with patch.object(bridge_module, "AuthConfig") as mock_auth_config:
+            bridge_module.get_kubernetes_client(cfg)
+
+    mock_auth_config.assert_called_once_with(
+        verify_ssl=True,
+        method="kubeconfig",
+        kubeconfig_path="/legacy/kubeconfig",
+    )
+    assert any("deprecated" in r.message.lower() for r in caplog.records)
+
+
+def test_legacy_context_only_warns_and_sets_kubeconfig_method(
+    authkit_available, bridge_module, caplog
+):
+    caplog.set_level(logging.WARNING)
+    cfg = KubernetesBackendConfig(context="my-context")
+
+    with patch.object(bridge_module, "kube_authkit_get_client", return_value=MagicMock()):
+        with patch.object(bridge_module, "AuthConfig") as mock_auth_config:
+            bridge_module.get_kubernetes_client(cfg)
+
+    mock_auth_config.assert_called_once_with(verify_ssl=True, method="kubeconfig")
+    assert any("deprecated" in r.message.lower() for r in caplog.records)
+
+
+def test_auto_detection_when_no_explicit_auth_params(authkit_available, bridge_module):
+    cfg = KubernetesBackendConfig()
+
+    with patch.object(bridge_module, "kube_authkit_get_client", return_value=MagicMock()):
+        with patch.object(bridge_module, "AuthConfig") as mock_auth_config:
+            bridge_module.get_kubernetes_client(cfg)
+
+    mock_auth_config.assert_called_once_with(verify_ssl=True, method="auto")
+
+
+def test_raises_import_error_when_kube_authkit_unavailable(bridge_module):
+    cfg = KubernetesBackendConfig()
+
+    with patch.object(bridge_module, "KUBE_AUTHKIT_AVAILABLE", False):
+        with pytest.raises(ImportError, match="kube-authkit"):
+            bridge_module.get_kubernetes_client(cfg)
+
+
+def test_kubeconfig_path_and_verify_ssl_propagate(authkit_available, bridge_module):
+    cfg = KubernetesBackendConfig(
+        auth_method="kubeconfig",
+        kubeconfig_path="/home/user/.kube/config",
+        verify_ssl=False,
+        k8s_api_host="https://cluster.local",
+        ca_cert="/etc/pki/ca.pem",
+    )
+
+    with patch.object(bridge_module, "kube_authkit_get_client", return_value=MagicMock()):
+        with patch.object(bridge_module, "AuthConfig") as mock_auth_config:
+            bridge_module.get_kubernetes_client(cfg)
+
+    mock_auth_config.assert_called_once_with(
+        verify_ssl=False,
+        k8s_api_host="https://cluster.local",
+        kubeconfig_path="/home/user/.kube/config",
+        ca_cert="/etc/pki/ca.pem",
+        method="kubeconfig",
+        use_keyring=False,
+    )
+
+
+def test_oidc_optional_scopes_omitted_when_none(authkit_available, bridge_module):
+    cfg = KubernetesBackendConfig(
+        auth_method="oidc",
+        oidc_issuer="https://issuer",
+        client_id="id",
+        scopes=None,
+    )
+
+    with patch.object(bridge_module, "kube_authkit_get_client", return_value=MagicMock()):
+        with patch.object(bridge_module, "AuthConfig") as mock_auth_config:
+            bridge_module.get_kubernetes_client(cfg)
+
+    _, kwargs = mock_auth_config.call_args
+    assert "scopes" not in kwargs
+
+
+def test_explicit_kubeconfig_does_not_emit_deprecation_warning(
+    authkit_available, bridge_module, caplog
+):
+    caplog.set_level(logging.WARNING)
+    cfg = KubernetesBackendConfig(
+        auth_method="kubeconfig",
+        kubeconfig_path="/path/config",
+    )
+
+    with patch.object(bridge_module, "kube_authkit_get_client", return_value=MagicMock()):
+        with patch.object(bridge_module, "AuthConfig"):
+            bridge_module.get_kubernetes_client(cfg)
+
+    assert not any("deprecated" in r.message.lower() for r in caplog.records)
+
+
+def test_kubeconfig_path_passed_with_auto_method(authkit_available, bridge_module):
+    """``kubeconfig_path`` without ``auth_method`` still reaches kube-authkit on the auto path."""
+    cfg = KubernetesBackendConfig(kubeconfig_path="/x/kubeconfig")
+
+    with patch.object(bridge_module, "kube_authkit_get_client", return_value=MagicMock()):
+        with patch.object(bridge_module, "AuthConfig") as mock_auth_config:
+            bridge_module.get_kubernetes_client(cfg)
+
+    mock_auth_config.assert_called_once_with(
+        verify_ssl=True,
+        kubeconfig_path="/x/kubeconfig",
+        method="auto",
+    )
+
+
+def test_incluster_auth_method_maps_common_fields(authkit_available, bridge_module):
+    cfg = KubernetesBackendConfig(
+        auth_method="incluster",
+        use_keyring=True,
+        verify_ssl=False,
+        k8s_api_host="https://kubernetes.default",
+    )
+
+    with patch.object(bridge_module, "kube_authkit_get_client", return_value=MagicMock()):
+        with patch.object(bridge_module, "AuthConfig") as mock_auth_config:
+            bridge_module.get_kubernetes_client(cfg)
+
+    mock_auth_config.assert_called_once_with(
+        verify_ssl=False,
+        k8s_api_host="https://kubernetes.default",
+        method="incluster",
+        use_keyring=True,
+    )
+
+
+def test_openshift_without_token_omits_token_key(authkit_available, bridge_module):
+    cfg = KubernetesBackendConfig(auth_method="openshift", token=None)
+
+    with patch.object(bridge_module, "kube_authkit_get_client", return_value=MagicMock()):
+        with patch.object(bridge_module, "AuthConfig") as mock_auth_config:
+            bridge_module.get_kubernetes_client(cfg)
+
+    _, kwargs = mock_auth_config.call_args
+    assert "token" not in kwargs

--- a/kubeflow/common/auth/types.py
+++ b/kubeflow/common/auth/types.py
@@ -1,0 +1,46 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Token credentials protocol for pluggable authentication."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from kubernetes.client import Configuration
+
+
+@runtime_checkable
+class TokenCredentialsBase(Protocol):
+    """Protocol for pluggable token credentials.
+
+    Any object that implements ``refresh_api_key_hook`` and ``get_token``
+    can be used as credentials for ``KubernetesBackendConfig`` and
+    ``load_kubernetes_config``.
+
+    ``refresh_api_key_hook`` is called by the Kubernetes Python client before
+    every API request, enabling automatic token refresh for K8s operations.
+
+    ``get_token`` returns a valid access token string for REST clients
+    (e.g. KFP, Model Registry) or any consumer that needs a raw bearer token.
+    """
+
+    def refresh_api_key_hook(self, config: Configuration) -> None:
+        """Called before every K8s API request to refresh the bearer token."""
+        ...
+
+    def get_token(self) -> str:
+        """Return a valid access token, refreshing if necessary."""
+        ...

--- a/kubeflow/common/types.py
+++ b/kubeflow/common/types.py
@@ -23,5 +23,26 @@ class KubernetesBackendConfig(BaseModel):
     context: str | None = None
     client_configuration: client.Configuration | None = None
 
+    # kube-authkit authentication fields
+    auth_method: str | None = None  # "auto", "kubeconfig", "incluster", "oidc", "openshift"
+    k8s_api_host: str | None = None
+    kubeconfig_path: str | None = None
+
+    # OIDC configuration
+    oidc_issuer: str | None = None
+    client_id: str | None = None
+    client_secret: str | None = None
+    scopes: list[str] | None = None
+    use_device_flow: bool = False
+    oidc_callback_port: int = 8080
+
+    # Token-based authentication
+    token: str | None = None
+
+    # Advanced options
+    use_keyring: bool = False
+    verify_ssl: bool = True
+    ca_cert: str | None = None
+
     class Config:
         arbitrary_types_allowed = True

--- a/kubeflow/common/types.py
+++ b/kubeflow/common/types.py
@@ -13,8 +13,15 @@
 # limitations under the License.
 
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from kubernetes import client
 from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from kubeflow.common.auth.types import TokenCredentialsBase
 
 
 class KubernetesBackendConfig(BaseModel):
@@ -22,6 +29,10 @@ class KubernetesBackendConfig(BaseModel):
     config_file: str | None = None
     context: str | None = None
     client_configuration: client.Configuration | None = None
+
+    # Pluggable credentials (satisfies TokenCredentialsBase protocol)
+    credentials: Any | None = None
+    server: str | None = None
 
     # kube-authkit authentication fields
     auth_method: str | None = None  # "auto", "kubeconfig", "incluster", "oidc", "openshift"
@@ -34,6 +45,7 @@ class KubernetesBackendConfig(BaseModel):
     client_secret: str | None = None
     scopes: list[str] | None = None
     use_device_flow: bool = False
+    use_client_credentials: bool = False
     oidc_callback_port: int = 8080
 
     # Token-based authentication

--- a/kubeflow/optimizer/backends/kubernetes/backend.py
+++ b/kubeflow/optimizer/backends/kubernetes/backend.py
@@ -23,7 +23,7 @@ from typing import Any
 import uuid
 
 from kubeflow_katib_api import models
-from kubernetes import client, config
+from kubernetes import client
 
 import kubeflow.common.constants as common_constants
 from kubeflow.common.types import KubernetesBackendConfig
@@ -52,15 +52,9 @@ class KubernetesBackend(RuntimeBackend):
         if cfg.namespace is None:
             cfg.namespace = common_utils.get_default_target_namespace(cfg.context)
 
-        # If client configuration is not set, use kube-config to access Kubernetes APIs.
-        if cfg.client_configuration is None:
-            # Load kube-config or in-cluster config.
-            if cfg.config_file or not common_utils.is_running_in_k8s():
-                config.load_kube_config(config_file=cfg.config_file, context=cfg.context)
-            else:
-                config.load_incluster_config()
+        from kubeflow.common.auth import get_kubernetes_client
 
-        k8s_client = client.ApiClient(cfg.client_configuration)
+        k8s_client = get_kubernetes_client(cfg)
         self.custom_api = client.CustomObjectsApi(k8s_client)
         self.core_api = client.CoreV1Api(k8s_client)
 

--- a/kubeflow/optimizer/backends/kubernetes/backend_test.py
+++ b/kubeflow/optimizer/backends/kubernetes/backend_test.py
@@ -33,7 +33,10 @@ from kubeflow.trainer.types.types import CustomTrainer, TrainJobTemplate
 def optimizer_backend():
     """Provide an optimizer KubernetesBackend with mocked Kubernetes APIs."""
     with (
-        patch("kubernetes.config.load_kube_config", return_value=None),
+        patch(
+            "kubeflow.common.auth.kube_authkit_bridge.kube_authkit_get_client",
+            return_value=Mock(),
+        ),
         patch(
             "kubernetes.client.CustomObjectsApi",
             return_value=Mock(

--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -27,7 +27,7 @@ import threading
 import time
 
 from kubeflow_spark_api import models
-from kubernetes import client, config
+from kubernetes import client
 from pyspark.sql import SparkSession
 
 from kubeflow.common import constants as common_constants
@@ -69,18 +69,11 @@ class KubernetesBackend(RuntimeBackend):
         """Initialize Kubernetes Spark backend."""
         self.namespace = backend_config.namespace or "default"
 
-        if backend_config.config_file:
-            config.load_kube_config(config_file=backend_config.config_file)
-        elif backend_config.context:
-            config.load_kube_config(context=backend_config.context)
-        else:
-            try:
-                config.load_incluster_config()
-            except config.ConfigException:
-                config.load_kube_config()
+        from kubeflow.common.auth import get_kubernetes_client
 
-        self.custom_api = client.CustomObjectsApi()
-        self.core_api = client.CoreV1Api()
+        k8s_client = get_kubernetes_client(backend_config)
+        self.custom_api = client.CustomObjectsApi(k8s_client)
+        self.core_api = client.CoreV1Api(k8s_client)
 
     def _extract_name_option(self, options: list | None) -> tuple[str, list]:
         """Extract Name option from options list, or generate name if absent.

--- a/kubeflow/spark/backends/kubernetes/backend_test.py
+++ b/kubeflow/spark/backends/kubernetes/backend_test.py
@@ -48,7 +48,10 @@ from kubeflow.spark.types.types import SparkConnectInfo, SparkConnectState
 def kubernetes_backend():
     """Provide KubernetesBackend with mocked K8s APIs."""
     with (
-        patch("kubernetes.config.load_kube_config", return_value=None),
+        patch(
+            "kubeflow.common.auth.kube_authkit_bridge.kube_authkit_get_client",
+            return_value=Mock(),
+        ),
         patch(
             "kubernetes.client.CustomObjectsApi",
             return_value=Mock(

--- a/kubeflow/trainer/api/trainer_client_test.py
+++ b/kubeflow/trainer/api/trainer_client_test.py
@@ -52,7 +52,10 @@ def test_backend_selection(test_case):
     """Test TrainerClient backend selection logic."""
     if test_case["use_k8s_mocks"]:
         with (
-            patch("kubernetes.config.load_kube_config"),
+            patch(
+                "kubeflow.common.auth.kube_authkit_bridge.kube_authkit_get_client",
+                return_value=Mock(),
+            ),
             patch("kubernetes.client.CustomObjectsApi") as mock_custom_api,
             patch("kubernetes.client.CoreV1Api") as mock_core_api,
         ):

--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -25,7 +25,7 @@ from typing import Any
 import uuid
 
 from kubeflow_trainer_api import models
-from kubernetes import client, config, watch
+from kubernetes import client, watch
 
 import kubeflow.common.constants as common_constants
 from kubeflow.common.types import KubernetesBackendConfig
@@ -43,15 +43,9 @@ class KubernetesBackend(RuntimeBackend):
         if cfg.namespace is None:
             cfg.namespace = common_utils.get_default_target_namespace(cfg.context)
 
-        # If client configuration is not set, use kube-config to access Kubernetes APIs.
-        if cfg.client_configuration is None:
-            # Load kube-config or in-cluster config.
-            if cfg.config_file or not common_utils.is_running_in_k8s():
-                config.load_kube_config(config_file=cfg.config_file, context=cfg.context)
-            else:
-                config.load_incluster_config()
+        from kubeflow.common.auth import get_kubernetes_client
 
-        k8s_client = client.ApiClient(cfg.client_configuration)
+        k8s_client = get_kubernetes_client(cfg)
         self.custom_api = client.CustomObjectsApi(k8s_client)
         self.core_api = client.CoreV1Api(k8s_client)
 

--- a/kubeflow/trainer/backends/kubernetes/backend_test.py
+++ b/kubeflow/trainer/backends/kubernetes/backend_test.py
@@ -85,7 +85,10 @@ TRAIN_JOB_WITH_CUSTOM_TRAINER = "train-job-with-custom-trainer"
 def kubernetes_backend(request):
     """Provide a KubernetesBackend with mocked Kubernetes APIs."""
     with (
-        patch("kubernetes.config.load_kube_config", return_value=None),
+        patch(
+            "kubeflow.common.auth.kube_authkit_bridge.kube_authkit_get_client",
+            return_value=Mock(),
+        ),
         patch(
             "kubernetes.client.CustomObjectsApi",
             return_value=Mock(
@@ -766,7 +769,10 @@ def _run_verify_backend_with_core_api(core_api: Mock) -> tuple[list[str], int]:
 
     try:
         with (
-            patch("kubernetes.config.load_kube_config", return_value=None),
+            patch(
+            "kubeflow.common.auth.kube_authkit_bridge.kube_authkit_get_client",
+            return_value=Mock(),
+        ),
             patch("kubeflow.common.utils.is_running_in_k8s", return_value=False),
             patch("kubernetes.client.ApiClient", return_value=Mock()),
             patch("kubernetes.client.CustomObjectsApi", return_value=Mock()),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,14 @@ classifiers = [
 ]
 dependencies = [
   "kubernetes>=27.2.0",
+  "kube-authkit>=0.2.0",
   "pydantic>=2.10.0",
   "kubeflow-trainer-api>=2.2.0",
   "kubeflow-katib-api>=0.19.0",
 ]
 
 [project.optional-dependencies]
+oidc = ["requests>=2.31.0"]
 docker = ["docker>=6.1.3"]
 podman = ["podman>=5.6.0"]
 spark = [


### PR DESCRIPTION
## Summary

This PR integrates [kube-authkit](https://pypi.org/project/kube-authkit/) as the primary path for building a Kubernetes `ApiClient` in the Kubeflow SDK, following the approach explored in opendatahub-io/kubeflow-sdk PR #53.

## Why

kube-authkit centralizes authentication for multiple methods (auto-detection, kubeconfig, in-cluster, OIDC flows, OpenShift OAuth) and maps cleanly onto a small set of config fields on `KubernetesBackendConfig`.

## Changes

- **`KubernetesBackendConfig`** (`kubeflow/common/types.py`): add ~14 optional fields aligned with kube-authkit `AuthConfig` (e.g. `auth_method`, `k8s_api_host`, `kubeconfig_path`, OIDC settings, `token`, `use_keyring`, `verify_ssl`, `ca_cert`).
- **Bridge** (`kubeflow/common/auth/kube_authkit_bridge.py`): `get_kubernetes_client()` translates config into `AuthConfig` and calls kube-authkit``s `get_k8s_client`. Re-exported from `kubeflow.common.auth` (`__init__.py`). *Note:* a top-level `kubeflow/common/auth.py` file would not be importable as `kubeflow.common.auth` alongside the `auth/` package, so the bridge lives under `auth/kube_authkit_bridge.py` with the same public import: `from kubeflow.common.auth import get_kubernetes_client`.
- **Backends**: trainer, optimizer, and Spark Kubernetes backends now use `get_kubernetes_client` instead of loading kubeconfig / in-cluster config inline.
- **`pyproject.toml`**: add hard dependency `kube-authkit>=0.2.0`.
- **Tests**: mock `kube_authkit_get_client` where kubeconfig loading was previously patched.

## Requirements

- Python `>=3.10` (already required by the project; kube-authkit wheels target supported versions).